### PR TITLE
feat: Specified Gem version of ActiveSupport

### DIFF
--- a/fluent-plugin-bigquery.gemspec
+++ b/fluent-plugin-bigquery.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "googleauth", ">= 0.5.0"
   spec.add_runtime_dependency "multi_json"
   spec.add_runtime_dependency "fluentd", ">= 0.14.0", "< 2"
+  spec.add_runtime_dependency "activesupport", "~> 6.1"
 end


### PR DESCRIPTION
    
- It causes dependency issue of tzinfo in fluent image
- https://docs.fluentd.org/quickstart/faq#fluentd-raises-tzinfo-conflict-error-after-installed-plugins